### PR TITLE
compatibility fixes for zeek v6.0.0

### DIFF
--- a/analyzer/main.zeek
+++ b/analyzer/main.zeek
@@ -307,13 +307,21 @@ event zeek_init() &priority=5 {
 }
 
 # triggered by SYNCHROPHASOR::FrameHeader::%done, set synchrophasor_proto according to analyzer
+@if (Version::at_least("6.1.0"))
 event analyzer_confirmation_info(atype: AllAnalyzers::Tag, info: AnalyzerConfirmationInfo) {
   if ( atype == Analyzer::ANALYZER_SYNCHROPHASOR_TCP ) {
     info$c$synchrophasor_proto = "tcp";
   } else if ( atype == Analyzer::ANALYZER_SYNCHROPHASOR_UDP ) {
     info$c$synchrophasor_proto = "udp";
   }
-
+@else
+event analyzer_confirmation(c: connection, atype: Analyzer::Tag, aid: count) &priority=5 {
+  if ( atype == Analyzer::ANALYZER_SYNCHROPHASOR_TCP ) {
+    c$synchrophasor_proto = "tcp";
+  } else if ( atype == Analyzer::ANALYZER_SYNCHROPHASOR_UDP ) {
+    c$synchrophasor_proto = "udp";
+  }
+@endif
 }
 
 # set_session_* functions for each of the synchrophasor frame events

--- a/zkg.meta
+++ b/zkg.meta
@@ -11,7 +11,6 @@ build_command = mkdir -p build && cd build && SPICYZ=$(command -v spicyz || echo
 test_command = cd tests && PATH=$(zkg config plugin_dir)/packages/spicy-plugin/bin:$PATH btest -d -j $(nproc)
 depends =
   zeek >=6.0.1
-  spicy >=1.8.1
 
 [template]
 source = package-template-spicy

--- a/zkg.meta
+++ b/zkg.meta
@@ -9,6 +9,9 @@ script_dir = analyzer
 plugin_dir = build/spicy-modules
 build_command = mkdir -p build && cd build && SPICYZ=$(command -v spicyz || echo %(package_base)s/spicy-plugin/build/bin/spicyz) cmake .. && cmake --build .
 test_command = cd tests && PATH=$(zkg config plugin_dir)/packages/spicy-plugin/bin:$PATH btest -d -j $(nproc)
+depends =
+  zeek >=6.0.1
+  spicy >=1.8.1
 
 [template]
 source = package-template-spicy

--- a/zkg.meta
+++ b/zkg.meta
@@ -10,7 +10,7 @@ plugin_dir = build/spicy-modules
 build_command = mkdir -p build && cd build && SPICYZ=$(command -v spicyz || echo %(package_base)s/spicy-plugin/build/bin/spicyz) cmake .. && cmake --build .
 test_command = cd tests && PATH=$(zkg config plugin_dir)/packages/spicy-plugin/bin:$PATH btest -d -j $(nproc)
 depends =
-  zeek >=6.0.1
+  zeek >=6.0.0
 
 [template]
 source = package-template-spicy


### PR DESCRIPTION
Two fixes (see #10 , although this plugin requires Zeek v6.0.0+)

* put an `@if` around analyzer_confirmation/analyzer_confirmation_info for Zeek versioning
* require zeek >= 6.0.0 in zkg.meta

