### PR TITLE
change comment format to avoid "discarded extraneous zeekygen comment" warnings

### DIFF
--- a/analyzer/main.zeek
+++ b/analyzer/main.zeek
@@ -1,14 +1,14 @@
-## main.zeek
-##
-## ICSNPP-Synchrophasor parser
-##
-## Zeek script type/record definitions describing the information
-## that will be written to the log files.
-##
-## Author:   Seth Grover
-## Contact:  Seth.Grover@inl.gov
-##
-## Copyright (c) 2023 Battelle Energy Alliance, LLC.  All rights reserved.
+##! main.zeek
+##!
+##! ICSNPP-Synchrophasor parser
+##!
+##! Zeek script type/record definitions describing the information
+##! that will be written to the log files.
+##!
+##! Author:   Seth Grover
+##! Contact:  Seth.Grover@inl.gov
+##!
+##! Copyright (c) 2023 Battelle Energy Alliance, LLC.  All rights reserved.
 
 module SYNCHROPHASOR;
 


### PR DESCRIPTION
Changed some double-pound comments to double-pound-bash comments to avoid 'discarded extraneous zeekygen comment' warning, see [zeekygen/example.zeek](https://github.com/zeek/zeek/blob/master/scripts/zeekygen/example.zeek) for reference.

Every time I run zeek with this script installed, we see something like this warning:

```
warning in ..., line 1: Discarded extraneous Zeekygen comment: Copyright (c) 2024 Battelle Energy Alliance, LLC.  All rights reserved.
```

If you read the file I linked, it talks about the difference between `#`, `##`, and `##!` comments.

This commit changes the `##` comments at the beginning of the file to `##!` comments.